### PR TITLE
Support remove monto and restore monto

### DIFF
--- a/application/packages/web/src/domain/model/monto.ts
+++ b/application/packages/web/src/domain/model/monto.ts
@@ -190,6 +190,8 @@ export const savedMontoSchema = v.union([
   inactiveMontoSchema,
 ]);
 
+export type SavedMonto = v.InferOutput<typeof savedMontoSchema>;
+
 export function newSavedMonto(
   input: v.InferInput<typeof savedMontoSchema>
 ): SavedMonto | Error {
@@ -245,5 +247,3 @@ export function modifiedSavedMonto(
 
   return updatedMonto;
 }
-
-export type SavedMonto = v.InferOutput<typeof savedMontoSchema>;

--- a/application/packages/web/src/domain/model/monto.ts
+++ b/application/packages/web/src/domain/model/monto.ts
@@ -274,3 +274,22 @@ export function inactiveSavedMonto(
 
   return inactiveMonto;
 }
+
+export function activeSavedMonto(
+  currentMonto: v.InferOutput<typeof inactiveMontoSchema>
+): ActiveMonto | Error {
+  let activeMonto: v.InferOutput<typeof activeMontoSchema>;
+  try {
+    activeMonto = v.parse(activeMontoSchema, {
+      ...currentMonto,
+    });
+  } catch (e: unknown) {
+    return new Error(
+      `Failed to parse input based on inactive monto schema: ${
+        e instanceof Error ? e.message : JSON.stringify(e)
+      }`
+    );
+  }
+
+  return activeMonto;
+}

--- a/application/packages/web/src/domain/model/monto.ts
+++ b/application/packages/web/src/domain/model/monto.ts
@@ -289,11 +289,13 @@ export function inactiveSavedMonto(
     );
   }
 
+  const newStatus: MontoStatus = "INACTIVE";
   let inactiveMonto: v.InferOutput<typeof inactiveMontoSchema>;
   try {
     inactiveMonto = v.parse(inactiveMontoSchema, {
       ...currentMonto,
       reason: parsedReason,
+      status: newStatus,
     });
   } catch (e: unknown) {
     return new InvalidMontoError(
@@ -309,10 +311,12 @@ export function inactiveSavedMonto(
 export function activeSavedMonto(
   currentMonto: v.InferOutput<typeof inactiveMontoSchema>
 ): ActiveMonto | Error {
+  const newStatus: MontoStatus = "ACTIVE";
   let activeMonto: v.InferOutput<typeof activeMontoSchema>;
   try {
     activeMonto = v.parse(activeMontoSchema, {
       ...currentMonto,
+      status: newStatus,
     });
   } catch (e: unknown) {
     return new InvalidMontoError(

--- a/application/packages/web/src/domain/model/monto.ts
+++ b/application/packages/web/src/domain/model/monto.ts
@@ -33,6 +33,16 @@ export function isMontoStatus(s: string): s is MontoStatus {
   return montoStatus.includes(s as MontoStatus);
 }
 
+export const inactiveMontoReason = [
+  "TEMPLE_TRANSFER",
+  "MISREGISTRATION",
+  "OTHERS",
+] as const;
+export type InactiveMontoReason = (typeof inactiveMontoReason)[number];
+export function isInactiveMontoReason(s: string): s is InactiveMontoReason {
+  return inactiveMontoReason.includes(s as InactiveMontoReason);
+}
+
 // in-source test suites
 if (import.meta.vitest) {
   const { it, expect, describe } = import.meta.vitest;
@@ -51,6 +61,18 @@ if (import.meta.vitest) {
     it("Should return true", () => {
       expect(isMontoStatus("ACTIVE")).toBe(true);
       expect(isMontoStatus("INACTIVE")).toBe(true);
+    });
+    it("Should return false", () => {
+      expect(isMontoStatus("MAN")).toBe(false);
+      expect(isMontoStatus("WOMAN")).toBe(false);
+    });
+  });
+
+  describe("isInactiveMontoReason", () => {
+    it("Should return true", () => {
+      expect(isInactiveMontoReason("OTHERS")).toBe(true);
+      expect(isInactiveMontoReason("TEMPLE_TRANSFER")).toBe(true);
+      expect(isInactiveMontoReason("MISREGISTRATION")).toBe(true);
     });
     it("Should return false", () => {
       expect(isMontoStatus("MAN")).toBe(false);
@@ -190,11 +212,7 @@ export const activeMontoSchema = v.pipe(
 
 export type ActiveMonto = v.InferOutput<typeof activeMontoSchema>;
 
-const inactiveMontoReasonSchema = v.pipe(
-  v.string(),
-  v.trim(),
-  v.minLength(1, "invalid reason length")
-);
+const inactiveMontoReasonSchema = v.picklist(inactiveMontoReason);
 
 export const inactiveMontoSchema = v.pipe(
   v.intersect([

--- a/application/packages/web/src/handler/api/removeMonto.ts
+++ b/application/packages/web/src/handler/api/removeMonto.ts
@@ -2,7 +2,7 @@ import { vValidator } from "@hono/valibot-validator";
 import { drizzle } from "drizzle-orm/d1";
 import { HTTPException } from "hono/http-exception";
 import * as v from "valibot";
-import { SavedMonto } from "../../domain/model/monto";
+import { inactiveMontoReason, SavedMonto } from "../../domain/model/monto";
 import {
   findOneForUpdate,
   updateMonto,
@@ -15,7 +15,7 @@ export const removeMonto = factory.createHandlers(
   vValidator(
     "json",
     v.object({
-      reason: v.string(),
+      reason: v.picklist(inactiveMontoReason),
     }),
     vValidatorHook()
   ),

--- a/application/packages/web/src/handler/api/removeMonto.ts
+++ b/application/packages/web/src/handler/api/removeMonto.ts
@@ -1,0 +1,33 @@
+import { vValidator } from "@hono/valibot-validator";
+import { drizzle } from "drizzle-orm/d1";
+import * as v from "valibot";
+import { SavedMonto } from "../../domain/model/monto";
+import {
+  findOneForUpdate,
+  updateMonto,
+} from "../../infrastructure/db/d1/monto";
+import { removeMonto as removeMontoUsecase } from "../../usecase/removeMonto";
+import { factory } from "../factory";
+import { vValidatorHook } from "../vValidator";
+
+export const removeMonto = factory.createHandlers(
+  vValidator(
+    "json",
+    v.object({
+      id: v.string(),
+      reason: v.string(),
+    }),
+    vValidatorHook()
+  ),
+  async (c) => {
+    const params = c.req.valid("json");
+    const db = drizzle(c.env.D1, { logger: true });
+
+    await removeMontoUsecase(params, {
+      findMonto: (id) => findOneForUpdate(db, id),
+      updateMonto: (savedMonto: SavedMonto) => updateMonto(db, savedMonto),
+    });
+
+    return c.json({ msg: "ok" });
+  }
+);

--- a/application/packages/web/src/handler/api/removeMonto.ts
+++ b/application/packages/web/src/handler/api/removeMonto.ts
@@ -3,6 +3,7 @@ import { drizzle } from "drizzle-orm/d1";
 import { HTTPException } from "hono/http-exception";
 import * as v from "valibot";
 import { inactiveMontoReason, SavedMonto } from "../../domain/model/monto";
+import { lock, unlock } from "../../infrastructure/db/d1/lock";
 import {
   findOneForUpdate,
   updateMonto,
@@ -39,6 +40,8 @@ export const removeMonto = factory.createHandlers(
       {
         findMonto: (id) => findOneForUpdate(db, id),
         updateMonto: (savedMonto: SavedMonto) => updateMonto(db, savedMonto),
+        lock: (key) => lock(db, key),
+        unlock: (key) => unlock(db, key),
       }
     );
 

--- a/application/packages/web/src/handler/api/restoreMonto.ts
+++ b/application/packages/web/src/handler/api/restoreMonto.ts
@@ -1,6 +1,7 @@
 import { drizzle } from "drizzle-orm/d1";
 import { HTTPException } from "hono/http-exception";
 import { SavedMonto } from "../../domain/model/monto";
+import { lock, unlock } from "../../infrastructure/db/d1/lock";
 import {
   findOneForUpdate,
   updateMonto,
@@ -24,6 +25,8 @@ export const restoreMonto = factory.createHandlers(async (c) => {
     {
       findMonto: (id) => findOneForUpdate(db, id),
       updateMonto: (savedMonto: SavedMonto) => updateMonto(db, savedMonto),
+      lock: (key) => lock(db, key),
+      unlock: (key) => unlock(db, key),
     }
   );
 

--- a/application/packages/web/src/handler/api/restoreMonto.ts
+++ b/application/packages/web/src/handler/api/restoreMonto.ts
@@ -1,0 +1,32 @@
+import { vValidator } from "@hono/valibot-validator";
+import { drizzle } from "drizzle-orm/d1";
+import * as v from "valibot";
+import { SavedMonto } from "../../domain/model/monto";
+import {
+  findOneForUpdate,
+  updateMonto,
+} from "../../infrastructure/db/d1/monto";
+import { restoreMonto as restoreMontoUsecase } from "../../usecase/restoreMonto";
+import { factory } from "../factory";
+import { vValidatorHook } from "../vValidator";
+
+export const restoreMonto = factory.createHandlers(
+  vValidator(
+    "json",
+    v.object({
+      id: v.string(),
+    }),
+    vValidatorHook()
+  ),
+  async (c) => {
+    const params = c.req.valid("json");
+    const db = drizzle(c.env.D1, { logger: true });
+
+    await restoreMontoUsecase(params, {
+      findMonto: (id) => findOneForUpdate(db, id),
+      updateMonto: (savedMonto: SavedMonto) => updateMonto(db, savedMonto),
+    });
+
+    return c.json({ msg: "ok" });
+  }
+);

--- a/application/packages/web/src/handler/editMontoAction.ts
+++ b/application/packages/web/src/handler/editMontoAction.ts
@@ -72,7 +72,7 @@ export const editMontoAction = factory.createHandlers(
             updateMontoD1(db, savedMonto),
           findMonto: (id) => findOneForUpdate(db, id),
           lock: (key) => lock(db, key),
-          unock: (key) => unlock(db, key),
+          unlock: (key) => unlock(db, key),
         }
       );
     } catch (e: unknown) {

--- a/application/packages/web/src/handler/editMontoAction.ts
+++ b/application/packages/web/src/handler/editMontoAction.ts
@@ -3,10 +3,12 @@ import { drizzle } from "drizzle-orm/d1";
 import { HTTPException } from "hono/http-exception";
 import * as v from "valibot";
 import { SavedMonto } from "../domain/model/monto";
+import { lock, unlock } from "../infrastructure/db/d1/lock";
 import {
   findOneForUpdate,
   updateMonto as updateMontoD1,
 } from "../infrastructure/db/d1/monto";
+import { ConflictError } from "../usecase/error/conflict";
 import { updateMonto as updateMontoUsecase } from "../usecase/updateMonto";
 import { factory } from "./factory";
 import { vValidatorHook } from "./vValidator";
@@ -57,18 +59,30 @@ export const editMontoAction = factory.createHandlers(
     const params = c.req.valid("form");
     const db = drizzle(c.env.D1, { logger: true });
 
-    await updateMontoUsecase(
-      {
-        ...params,
-        phoneNumber: params["phone-number"],
-        dateOfDeath: params["date-of-death"],
-        id,
-      },
-      {
-        updateMonto: (savedMonto: SavedMonto) => updateMontoD1(db, savedMonto),
-        findMonto: (id) => findOneForUpdate(db, id),
+    try {
+      await updateMontoUsecase(
+        {
+          ...params,
+          phoneNumber: params["phone-number"],
+          dateOfDeath: params["date-of-death"],
+          id,
+        },
+        {
+          updateMonto: (savedMonto: SavedMonto) =>
+            updateMontoD1(db, savedMonto),
+          findMonto: (id) => findOneForUpdate(db, id),
+          lock: (key) => lock(db, key),
+          unock: (key) => unlock(db, key),
+        }
+      );
+    } catch (e: unknown) {
+      if (e instanceof ConflictError) {
+        throw new HTTPException(409, {
+          message: e.message,
+        });
       }
-    );
+      throw e;
+    }
 
     return c.redirect("/montos");
   }

--- a/application/packages/web/src/index.tsx
+++ b/application/packages/web/src/index.tsx
@@ -17,6 +17,8 @@ import { editMonto } from "./handler/editMonto";
 import { editMontoAction } from "./handler/editMontoAction";
 import { removeMonto } from "./handler/api/removeMonto";
 import { restoreMonto } from "./handler/api/restoreMonto";
+import Error409 from "./pages/409";
+import { ContentfulStatusCode } from "hono/utils/http-status";
 
 const montoApp = new Hono<{ Bindings: Bindings }>()
   .get("/", ...montos)
@@ -35,16 +37,27 @@ const apiApp = new Hono<{ Bindings: Bindings }>()
   .onError((err, c) => {
     console.error(err);
 
-    if (
-      err instanceof InvalidParameterError ||
-      (err instanceof HTTPException && err.status === 400)
-    ) {
+    const isHTTPException = (status: ContentfulStatusCode) => {
+      return err instanceof HTTPException && err.status === status;
+    };
+
+    if (err instanceof InvalidParameterError || isHTTPException(400)) {
       return c.json(
         {
           msg: "Bad request",
           detail: err.message,
         },
         400
+      );
+    }
+
+    if (err instanceof InvalidParameterError || isHTTPException(409)) {
+      return c.json(
+        {
+          msg: "Conflict",
+          detail: err.message,
+        },
+        409
       );
     }
 
@@ -63,8 +76,14 @@ const app = new Hono<{ Bindings: Bindings }>()
   .onError((err, c) => {
     console.error(err);
 
-    if (err instanceof HTTPException && err.status === 404) {
-      return c.render(<Error404 />);
+    if (err instanceof HTTPException) {
+      if (err.status === 404) {
+        return c.render(<Error404 />);
+      }
+
+      if (err.status === 409) {
+        return c.render(<Error409 />);
+      }
     }
 
     return c.render(<Error500 />);

--- a/application/packages/web/src/index.tsx
+++ b/application/packages/web/src/index.tsx
@@ -15,6 +15,8 @@ import Error500 from "./pages/500";
 import Error404 from "./pages/404";
 import { editMonto } from "./handler/editMonto";
 import { editMontoAction } from "./handler/editMontoAction";
+import { removeMonto } from "./handler/api/removeMonto";
+import { restoreMonto } from "./handler/api/restoreMonto";
 
 const montoApp = new Hono<{ Bindings: Bindings }>()
   .get("/", ...montos)
@@ -53,7 +55,9 @@ const apiApp = new Hono<{ Bindings: Bindings }>()
       500
     );
   })
-  .post("/montos/_batch", ...insertManyMontos);
+  .post("/montos/_batch", ...insertManyMontos)
+  .post("/montos/removals", ...removeMonto)
+  .post("/montos/restoration", ...restoreMonto);
 
 const app = new Hono<{ Bindings: Bindings }>()
   .onError((err, c) => {

--- a/application/packages/web/src/index.tsx
+++ b/application/packages/web/src/index.tsx
@@ -56,8 +56,8 @@ const apiApp = new Hono<{ Bindings: Bindings }>()
     );
   })
   .post("/montos/_batch", ...insertManyMontos)
-  .post("/montos/removals", ...removeMonto)
-  .post("/montos/restoration", ...restoreMonto);
+  .post("/montos/:id/removals", ...removeMonto)
+  .post("/montos/:id/restorations", ...restoreMonto);
 
 const app = new Hono<{ Bindings: Bindings }>()
   .onError((err, c) => {

--- a/application/packages/web/src/index.tsx
+++ b/application/packages/web/src/index.tsx
@@ -63,7 +63,6 @@ const app = new Hono<{ Bindings: Bindings }>()
       return c.render(<Error404 />);
     }
 
-    // Error generated after passing html input validation are not expected.
     return c.render(<Error500 />);
   })
   .use(

--- a/application/packages/web/src/infrastructure/db/d1/lock.ts
+++ b/application/packages/web/src/infrastructure/db/d1/lock.ts
@@ -2,17 +2,36 @@ import { eq } from "drizzle-orm";
 import { DrizzleD1Database } from "drizzle-orm/d1";
 import { locks } from "./schema";
 
-export async function getLock(
+/**
+ * @description
+ * Return false if already locked.
+ */
+export async function lock(
   db: DrizzleD1Database,
   key: string
-): Promise<void> {
-  await db.insert(locks).values({
-    key,
-    lockedDate: new Date().toISOString(),
-  });
+): Promise<boolean> {
+  return await db
+    .insert(locks)
+    .values({
+      key,
+      lockedDate: new Date().toISOString(),
+    })
+    .then(() => true)
+    .catch((e: unknown) => {
+      // D1 does not throw extended error class when unique constraint error occurs.
+      if (
+        e instanceof Error &&
+        e.message ===
+          "D1_ERROR: UNIQUE constraint failed: locks.key: SQLITE_CONSTRAINT"
+      ) {
+        return false;
+      }
+
+      throw e;
+    });
 }
 
-export async function releaseLock(
+export async function unlock(
   db: DrizzleD1Database,
   key: string
 ): Promise<void> {

--- a/application/packages/web/src/infrastructure/db/d1/lock.ts
+++ b/application/packages/web/src/infrastructure/db/d1/lock.ts
@@ -1,0 +1,20 @@
+import { eq } from "drizzle-orm";
+import { DrizzleD1Database } from "drizzle-orm/d1";
+import { locks } from "./schema";
+
+export async function getLock(
+  db: DrizzleD1Database,
+  key: string
+): Promise<void> {
+  await db.insert(locks).values({
+    key,
+    lockedDate: new Date().toISOString(),
+  });
+}
+
+export async function releaseLock(
+  db: DrizzleD1Database,
+  key: string
+): Promise<void> {
+  await db.delete(locks).where(eq(locks.key, key));
+}

--- a/application/packages/web/src/infrastructure/db/d1/migrations/0007_shiny_senator_kelly.sql
+++ b/application/packages/web/src/infrastructure/db/d1/migrations/0007_shiny_senator_kelly.sql
@@ -1,0 +1,22 @@
+CREATE TABLE `remove_montos` (
+	`id` text PRIMARY KEY NOT NULL,
+	`monto_id` text NOT NULL,
+	`reason` text NOT NULL,
+	`note` text,
+	`removed_date` text NOT NULL,
+	FOREIGN KEY (`monto_id`) REFERENCES `montos`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `remove_montos_monto_id_unique` ON `remove_montos` (`monto_id`);--> statement-breakpoint
+CREATE TABLE `restore_montos` (
+	`id` text PRIMARY KEY NOT NULL,
+	`monto_id` text NOT NULL,
+	`note` text,
+	`restored_date` text NOT NULL,
+	FOREIGN KEY (`monto_id`) REFERENCES `montos`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `restore_montos_monto_id_unique` ON `restore_montos` (`monto_id`);--> statement-breakpoint
+ALTER TABLE `montos` ADD `status` text DEFAULT 'ACTIVE' NOT NULL;--> statement-breakpoint
+CREATE VIEW `active_montos` AS select "id", "genderId", "first_name", "last_name", "phone_number", "address", "status", "date_of_death", "created_date", "updated_date" from "montos" where "montos"."status" = 'ACTIVE';--> statement-breakpoint
+CREATE VIEW `inactive_montos` AS select "id", "genderId", "first_name", "last_name", "phone_number", "address", "status", "date_of_death", "created_date", "updated_date" from "montos" where "montos"."status" = 'INACTIVE';

--- a/application/packages/web/src/infrastructure/db/d1/migrations/0008_high_doctor_spectrum.sql
+++ b/application/packages/web/src/infrastructure/db/d1/migrations/0008_high_doctor_spectrum.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `remove_montos` DROP COLUMN `note`;--> statement-breakpoint
+ALTER TABLE `restore_montos` DROP COLUMN `note`;

--- a/application/packages/web/src/infrastructure/db/d1/migrations/0009_freezing_living_tribunal.sql
+++ b/application/packages/web/src/infrastructure/db/d1/migrations/0009_freezing_living_tribunal.sql
@@ -1,0 +1,2 @@
+DROP INDEX `remove_montos_monto_id_unique`;--> statement-breakpoint
+DROP INDEX `restore_montos_monto_id_unique`;

--- a/application/packages/web/src/infrastructure/db/d1/migrations/0010_old_phalanx.sql
+++ b/application/packages/web/src/infrastructure/db/d1/migrations/0010_old_phalanx.sql
@@ -1,0 +1,4 @@
+CREATE TABLE `locks` (
+	`key` text PRIMARY KEY NOT NULL,
+	`locked_date` text NOT NULL
+);

--- a/application/packages/web/src/infrastructure/db/d1/migrations/meta/0007_snapshot.json
+++ b/application/packages/web/src/infrastructure/db/d1/migrations/meta/0007_snapshot.json
@@ -1,0 +1,509 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "808a580f-abbb-404f-92ff-260910c153d2",
+  "prevId": "a348d087-6077-48ac-9959-63474fd35d59",
+  "tables": {
+    "buddhist_profiles": {
+      "name": "buddhist_profiles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "monto_id": {
+          "name": "monto_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "homyo": {
+          "name": "homyo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ingou": {
+          "name": "ingou",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_date": {
+          "name": "created_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "buddhist_profiles_monto_id_unique": {
+          "name": "buddhist_profiles_monto_id_unique",
+          "columns": [
+            "monto_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "buddhist_profiles_monto_id_montos_id_fk": {
+          "name": "buddhist_profiles_monto_id_montos_id_fk",
+          "tableFrom": "buddhist_profiles",
+          "tableTo": "montos",
+          "columnsFrom": [
+            "monto_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "genders": {
+      "name": "genders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_date": {
+          "name": "created_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "montos": {
+      "name": "montos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genderId": {
+          "name": "genderId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "date_of_death": {
+          "name": "date_of_death",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_date": {
+          "name": "created_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "montos_genderId_genders_id_fk": {
+          "name": "montos_genderId_genders_id_fk",
+          "tableFrom": "montos",
+          "tableTo": "genders",
+          "columnsFrom": [
+            "genderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remove_montos": {
+      "name": "remove_montos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "monto_id": {
+          "name": "monto_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_date": {
+          "name": "removed_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remove_montos_monto_id_unique": {
+          "name": "remove_montos_monto_id_unique",
+          "columns": [
+            "monto_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remove_montos_monto_id_montos_id_fk": {
+          "name": "remove_montos_monto_id_montos_id_fk",
+          "tableFrom": "remove_montos",
+          "tableTo": "montos",
+          "columnsFrom": [
+            "monto_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "restore_montos": {
+      "name": "restore_montos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "monto_id": {
+          "name": "monto_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "restored_date": {
+          "name": "restored_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "restore_montos_monto_id_unique": {
+          "name": "restore_montos_monto_id_unique",
+          "columns": [
+            "monto_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "restore_montos_monto_id_montos_id_fk": {
+          "name": "restore_montos_monto_id_montos_id_fk",
+          "tableFrom": "restore_montos",
+          "tableTo": "montos",
+          "columnsFrom": [
+            "monto_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {
+    "active_montos": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genderId": {
+          "name": "genderId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "date_of_death": {
+          "name": "date_of_death",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_date": {
+          "name": "created_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "name": "active_montos",
+      "isExisting": false,
+      "definition": "select \"id\", \"genderId\", \"first_name\", \"last_name\", \"phone_number\", \"address\", \"status\", \"date_of_death\", \"created_date\", \"updated_date\" from \"montos\" where \"montos\".\"status\" = 'ACTIVE'"
+    },
+    "inactive_montos": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genderId": {
+          "name": "genderId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "date_of_death": {
+          "name": "date_of_death",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_date": {
+          "name": "created_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "name": "inactive_montos",
+      "isExisting": false,
+      "definition": "select \"id\", \"genderId\", \"first_name\", \"last_name\", \"phone_number\", \"address\", \"status\", \"date_of_death\", \"created_date\", \"updated_date\" from \"montos\" where \"montos\".\"status\" = 'INACTIVE'"
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/application/packages/web/src/infrastructure/db/d1/migrations/meta/0008_snapshot.json
+++ b/application/packages/web/src/infrastructure/db/d1/migrations/meta/0008_snapshot.json
@@ -1,0 +1,495 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0cb55ed4-c89a-46f0-970e-9e6e926cf213",
+  "prevId": "808a580f-abbb-404f-92ff-260910c153d2",
+  "tables": {
+    "buddhist_profiles": {
+      "name": "buddhist_profiles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "monto_id": {
+          "name": "monto_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "homyo": {
+          "name": "homyo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ingou": {
+          "name": "ingou",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_date": {
+          "name": "created_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "buddhist_profiles_monto_id_unique": {
+          "name": "buddhist_profiles_monto_id_unique",
+          "columns": [
+            "monto_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "buddhist_profiles_monto_id_montos_id_fk": {
+          "name": "buddhist_profiles_monto_id_montos_id_fk",
+          "tableFrom": "buddhist_profiles",
+          "tableTo": "montos",
+          "columnsFrom": [
+            "monto_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "genders": {
+      "name": "genders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_date": {
+          "name": "created_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "montos": {
+      "name": "montos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genderId": {
+          "name": "genderId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "date_of_death": {
+          "name": "date_of_death",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_date": {
+          "name": "created_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "montos_genderId_genders_id_fk": {
+          "name": "montos_genderId_genders_id_fk",
+          "tableFrom": "montos",
+          "tableTo": "genders",
+          "columnsFrom": [
+            "genderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remove_montos": {
+      "name": "remove_montos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "monto_id": {
+          "name": "monto_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "removed_date": {
+          "name": "removed_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remove_montos_monto_id_unique": {
+          "name": "remove_montos_monto_id_unique",
+          "columns": [
+            "monto_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remove_montos_monto_id_montos_id_fk": {
+          "name": "remove_montos_monto_id_montos_id_fk",
+          "tableFrom": "remove_montos",
+          "tableTo": "montos",
+          "columnsFrom": [
+            "monto_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "restore_montos": {
+      "name": "restore_montos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "monto_id": {
+          "name": "monto_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "restored_date": {
+          "name": "restored_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "restore_montos_monto_id_unique": {
+          "name": "restore_montos_monto_id_unique",
+          "columns": [
+            "monto_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "restore_montos_monto_id_montos_id_fk": {
+          "name": "restore_montos_monto_id_montos_id_fk",
+          "tableFrom": "restore_montos",
+          "tableTo": "montos",
+          "columnsFrom": [
+            "monto_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {
+    "active_montos": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genderId": {
+          "name": "genderId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "date_of_death": {
+          "name": "date_of_death",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_date": {
+          "name": "created_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "name": "active_montos",
+      "isExisting": false,
+      "definition": "select \"id\", \"genderId\", \"first_name\", \"last_name\", \"phone_number\", \"address\", \"status\", \"date_of_death\", \"created_date\", \"updated_date\" from \"montos\" where \"montos\".\"status\" = 'ACTIVE'"
+    },
+    "inactive_montos": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genderId": {
+          "name": "genderId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "date_of_death": {
+          "name": "date_of_death",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_date": {
+          "name": "created_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "name": "inactive_montos",
+      "isExisting": false,
+      "definition": "select \"id\", \"genderId\", \"first_name\", \"last_name\", \"phone_number\", \"address\", \"status\", \"date_of_death\", \"created_date\", \"updated_date\" from \"montos\" where \"montos\".\"status\" = 'INACTIVE'"
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/application/packages/web/src/infrastructure/db/d1/migrations/meta/0009_snapshot.json
+++ b/application/packages/web/src/infrastructure/db/d1/migrations/meta/0009_snapshot.json
@@ -1,0 +1,479 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "14d1ed11-889b-4451-ab28-6bc32c5d15b4",
+  "prevId": "0cb55ed4-c89a-46f0-970e-9e6e926cf213",
+  "tables": {
+    "buddhist_profiles": {
+      "name": "buddhist_profiles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "monto_id": {
+          "name": "monto_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "homyo": {
+          "name": "homyo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ingou": {
+          "name": "ingou",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_date": {
+          "name": "created_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "buddhist_profiles_monto_id_unique": {
+          "name": "buddhist_profiles_monto_id_unique",
+          "columns": [
+            "monto_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "buddhist_profiles_monto_id_montos_id_fk": {
+          "name": "buddhist_profiles_monto_id_montos_id_fk",
+          "tableFrom": "buddhist_profiles",
+          "tableTo": "montos",
+          "columnsFrom": [
+            "monto_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "genders": {
+      "name": "genders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_date": {
+          "name": "created_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "montos": {
+      "name": "montos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genderId": {
+          "name": "genderId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "date_of_death": {
+          "name": "date_of_death",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_date": {
+          "name": "created_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "montos_genderId_genders_id_fk": {
+          "name": "montos_genderId_genders_id_fk",
+          "tableFrom": "montos",
+          "tableTo": "genders",
+          "columnsFrom": [
+            "genderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remove_montos": {
+      "name": "remove_montos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "monto_id": {
+          "name": "monto_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "removed_date": {
+          "name": "removed_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "remove_montos_monto_id_montos_id_fk": {
+          "name": "remove_montos_monto_id_montos_id_fk",
+          "tableFrom": "remove_montos",
+          "tableTo": "montos",
+          "columnsFrom": [
+            "monto_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "restore_montos": {
+      "name": "restore_montos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "monto_id": {
+          "name": "monto_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "restored_date": {
+          "name": "restored_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "restore_montos_monto_id_montos_id_fk": {
+          "name": "restore_montos_monto_id_montos_id_fk",
+          "tableFrom": "restore_montos",
+          "tableTo": "montos",
+          "columnsFrom": [
+            "monto_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {
+    "active_montos": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genderId": {
+          "name": "genderId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "date_of_death": {
+          "name": "date_of_death",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_date": {
+          "name": "created_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "name": "active_montos",
+      "isExisting": false,
+      "definition": "select \"id\", \"genderId\", \"first_name\", \"last_name\", \"phone_number\", \"address\", \"status\", \"date_of_death\", \"created_date\", \"updated_date\" from \"montos\" where \"montos\".\"status\" = 'ACTIVE'"
+    },
+    "inactive_montos": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genderId": {
+          "name": "genderId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "date_of_death": {
+          "name": "date_of_death",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_date": {
+          "name": "created_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "name": "inactive_montos",
+      "isExisting": false,
+      "definition": "select \"id\", \"genderId\", \"first_name\", \"last_name\", \"phone_number\", \"address\", \"status\", \"date_of_death\", \"created_date\", \"updated_date\" from \"montos\" where \"montos\".\"status\" = 'INACTIVE'"
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/application/packages/web/src/infrastructure/db/d1/migrations/meta/0010_snapshot.json
+++ b/application/packages/web/src/infrastructure/db/d1/migrations/meta/0010_snapshot.json
@@ -1,0 +1,503 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "cbf0a7ae-fc7b-44ee-8ff5-d07ecf487126",
+  "prevId": "14d1ed11-889b-4451-ab28-6bc32c5d15b4",
+  "tables": {
+    "buddhist_profiles": {
+      "name": "buddhist_profiles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "monto_id": {
+          "name": "monto_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "homyo": {
+          "name": "homyo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ingou": {
+          "name": "ingou",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_date": {
+          "name": "created_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "buddhist_profiles_monto_id_unique": {
+          "name": "buddhist_profiles_monto_id_unique",
+          "columns": [
+            "monto_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "buddhist_profiles_monto_id_montos_id_fk": {
+          "name": "buddhist_profiles_monto_id_montos_id_fk",
+          "tableFrom": "buddhist_profiles",
+          "tableTo": "montos",
+          "columnsFrom": [
+            "monto_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "genders": {
+      "name": "genders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_date": {
+          "name": "created_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locks": {
+      "name": "locks",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locked_date": {
+          "name": "locked_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "montos": {
+      "name": "montos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genderId": {
+          "name": "genderId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "date_of_death": {
+          "name": "date_of_death",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_date": {
+          "name": "created_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "montos_genderId_genders_id_fk": {
+          "name": "montos_genderId_genders_id_fk",
+          "tableFrom": "montos",
+          "tableTo": "genders",
+          "columnsFrom": [
+            "genderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remove_montos": {
+      "name": "remove_montos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "monto_id": {
+          "name": "monto_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "removed_date": {
+          "name": "removed_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "remove_montos_monto_id_montos_id_fk": {
+          "name": "remove_montos_monto_id_montos_id_fk",
+          "tableFrom": "remove_montos",
+          "tableTo": "montos",
+          "columnsFrom": [
+            "monto_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "restore_montos": {
+      "name": "restore_montos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "monto_id": {
+          "name": "monto_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "restored_date": {
+          "name": "restored_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "restore_montos_monto_id_montos_id_fk": {
+          "name": "restore_montos_monto_id_montos_id_fk",
+          "tableFrom": "restore_montos",
+          "tableTo": "montos",
+          "columnsFrom": [
+            "monto_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {
+    "active_montos": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genderId": {
+          "name": "genderId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "date_of_death": {
+          "name": "date_of_death",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_date": {
+          "name": "created_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "name": "active_montos",
+      "isExisting": false,
+      "definition": "select \"id\", \"genderId\", \"first_name\", \"last_name\", \"phone_number\", \"address\", \"status\", \"date_of_death\", \"created_date\", \"updated_date\" from \"montos\" where \"montos\".\"status\" = 'ACTIVE'"
+    },
+    "inactive_montos": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genderId": {
+          "name": "genderId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "date_of_death": {
+          "name": "date_of_death",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_date": {
+          "name": "created_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "name": "inactive_montos",
+      "isExisting": false,
+      "definition": "select \"id\", \"genderId\", \"first_name\", \"last_name\", \"phone_number\", \"address\", \"status\", \"date_of_death\", \"created_date\", \"updated_date\" from \"montos\" where \"montos\".\"status\" = 'INACTIVE'"
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/application/packages/web/src/infrastructure/db/d1/migrations/meta/_journal.json
+++ b/application/packages/web/src/infrastructure/db/d1/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1739688828026,
       "tag": "0006_soft_blue_blade",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1740667557075,
+      "tag": "0007_shiny_senator_kelly",
+      "breakpoints": true
     }
   ]
 }

--- a/application/packages/web/src/infrastructure/db/d1/migrations/meta/_journal.json
+++ b/application/packages/web/src/infrastructure/db/d1/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1740667557075,
       "tag": "0007_shiny_senator_kelly",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1740697313280,
+      "tag": "0008_high_doctor_spectrum",
+      "breakpoints": true
     }
   ]
 }

--- a/application/packages/web/src/infrastructure/db/d1/migrations/meta/_journal.json
+++ b/application/packages/web/src/infrastructure/db/d1/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1740697313280,
       "tag": "0008_high_doctor_spectrum",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1740759653288,
+      "tag": "0009_freezing_living_tribunal",
+      "breakpoints": true
     }
   ]
 }

--- a/application/packages/web/src/infrastructure/db/d1/migrations/meta/_journal.json
+++ b/application/packages/web/src/infrastructure/db/d1/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1740759653288,
       "tag": "0009_freezing_living_tribunal",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1740761552191,
+      "tag": "0010_old_phalanx",
+      "breakpoints": true
     }
   ]
 }

--- a/application/packages/web/src/infrastructure/db/d1/monto.ts
+++ b/application/packages/web/src/infrastructure/db/d1/monto.ts
@@ -146,10 +146,7 @@ export async function updateMonto(
     throw new Error("gender not found");
   }
 
-  const createdDate = new Date().toISOString();
   const updatedDate = new Date().toISOString();
-
-  console.log(savedMonto);
 
   // NOTE: Cloudflare D1 transaction not supported
   // https://github.com/drizzle-team/drizzle-orm/issues/2463
@@ -165,7 +162,6 @@ export async function updateMonto(
         dateOfDeath: savedMonto.dateOfDeath
           ? savedMonto.dateOfDeath.toISOString()
           : null,
-        createdDate,
         updatedDate,
       })
       .where(eq(montos.id, savedMonto.id)),
@@ -174,7 +170,6 @@ export async function updateMonto(
       .set({
         homyo: savedMonto.homyo ?? null,
         ingou: savedMonto.ingou ?? null,
-        createdDate,
         updatedDate,
       })
       .where(eq(buddhistProfiles.montoId, savedMonto.id)),

--- a/application/packages/web/src/infrastructure/db/d1/monto.ts
+++ b/application/packages/web/src/infrastructure/db/d1/monto.ts
@@ -167,28 +167,27 @@ export async function updateMonto(
   }
 
   let queryToInsertEvent;
-  if (selectedMonto.status === savedMonto.status) {
-    return undefined;
-  }
-  const savedMontoStatus = savedMonto.status;
-  switch (savedMontoStatus) {
-    case "ACTIVE":
-      queryToInsertEvent = db.insert(restoreMontos).values({
-        id: randomUUID(),
-        montoId: savedMonto.id,
-        restoredDate: now,
-      });
-      break;
-    case "INACTIVE":
-      queryToInsertEvent = db.insert(removeMontos).values({
-        id: randomUUID(),
-        montoId: savedMonto.id,
-        removedDate: now,
-        reason: savedMonto.reason,
-      });
-      break;
-    default:
-      throw new Error(savedMontoStatus satisfies never);
+  if (selectedMonto.status !== savedMonto.status) {
+    const savedMontoStatus = savedMonto.status;
+    switch (savedMontoStatus) {
+      case "ACTIVE":
+        queryToInsertEvent = db.insert(restoreMontos).values({
+          id: randomUUID(),
+          montoId: savedMonto.id,
+          restoredDate: now,
+        });
+        break;
+      case "INACTIVE":
+        queryToInsertEvent = db.insert(removeMontos).values({
+          id: randomUUID(),
+          montoId: savedMonto.id,
+          removedDate: now,
+          reason: savedMonto.reason,
+        });
+        break;
+      default:
+        throw new Error(savedMontoStatus satisfies never);
+    }
   }
 
   const updatedDate = now;

--- a/application/packages/web/src/infrastructure/db/d1/monto.ts
+++ b/application/packages/web/src/infrastructure/db/d1/monto.ts
@@ -2,6 +2,7 @@ import { desc, eq } from "drizzle-orm";
 import { DrizzleD1Database } from "drizzle-orm/d1";
 import { randomUUID } from "node:crypto";
 import {
+  isInactiveMontoReason,
   isMontoStatus,
   newSavedMonto,
   SavedMonto,
@@ -54,6 +55,10 @@ export async function findOneForUpdate(
       throw new Error(
         `Removed monto event not found: monto id = ${selectedMonto.id}`
       );
+    }
+
+    if (!isInactiveMontoReason(result.reason)) {
+      throw new Error(`Invalid inactive monto reason: ${result.reason}`);
     }
 
     return result.reason;

--- a/application/packages/web/src/infrastructure/db/d1/monto.ts
+++ b/application/packages/web/src/infrastructure/db/d1/monto.ts
@@ -90,6 +90,8 @@ export async function insertMonto(
   db: DrizzleD1Database,
   unsavedMonto: UnsavedMonto
 ): Promise<void> {
+  const now = new Date().toISOString();
+
   const selectedGender = await db
     .select({ id: genders.id })
     .from(genders)
@@ -100,8 +102,8 @@ export async function insertMonto(
     throw new Error("gender not found");
   }
 
-  const createdDate = new Date().toISOString();
-  const updatedDate = new Date().toISOString();
+  const createdDate = now;
+  const updatedDate = now;
 
   // NOTE: Cloudflare D1 transaction not supported
   // https://github.com/drizzle-team/drizzle-orm/issues/2463

--- a/application/packages/web/src/infrastructure/db/d1/montoReader.ts
+++ b/application/packages/web/src/infrastructure/db/d1/montoReader.ts
@@ -2,7 +2,7 @@ import { eq, like } from "drizzle-orm";
 import { DrizzleD1Database } from "drizzle-orm/d1";
 import { Gender, isGender } from "../../../domain/model/monto";
 import { nextNenki } from "../../../domain/service/nenki";
-import { buddhistProfiles, genders, montos } from "./schema";
+import { activeMontos, buddhistProfiles, genders } from "./schema";
 
 type FindManyMontosWithPageResponse = {
   totalCount: number;
@@ -30,13 +30,13 @@ export async function findManyMontosWithPage(
 ): Promise<FindManyMontosWithPageResponse> {
   const query = db
     .select()
-    .from(montos)
-    .innerJoin(genders, eq(montos.genderId, genders.id))
-    .leftJoin(buddhistProfiles, eq(montos.id, buddhistProfiles.montoId))
+    .from(activeMontos)
+    .innerJoin(genders, eq(activeMontos.genderId, genders.id))
+    .leftJoin(buddhistProfiles, eq(activeMontos.id, buddhistProfiles.montoId))
     .$dynamic();
 
   if (params.lastName) {
-    query.where(like(montos.lastName, `%${params.lastName}%`));
+    query.where(like(activeMontos.lastName, `%${params.lastName}%`));
   }
 
   const results = await query;
@@ -49,20 +49,20 @@ export async function findManyMontosWithPage(
       }
 
       return {
-        id: result.montos.id,
+        id: result.active_montos.id,
         homyo: result.buddhist_profiles?.homyo ?? undefined,
-        firstName: result.montos.firstName,
-        lastName: result.montos.lastName,
+        firstName: result.active_montos.firstName,
+        lastName: result.active_montos.lastName,
         ingou: result.buddhist_profiles?.ingou ?? undefined,
-        dateOfDeath: result.montos.dateOfDeath
-          ? new Date(result.montos.dateOfDeath)
+        dateOfDeath: result.active_montos.dateOfDeath
+          ? new Date(result.active_montos.dateOfDeath)
           : undefined,
-        address: result.montos.address,
-        nextNenki: result.montos.dateOfDeath
-          ? nextNenki(new Date(result.montos.dateOfDeath))
+        address: result.active_montos.address,
+        nextNenki: result.active_montos.dateOfDeath
+          ? nextNenki(new Date(result.active_montos.dateOfDeath))
           : undefined,
         gender: result.genders.type,
-        phoneNumber: result.montos.phoneNumber,
+        phoneNumber: result.active_montos.phoneNumber,
       };
     }),
   };
@@ -91,10 +91,10 @@ export async function findOneMonto(
 ): Promise<FindOneMontoResponse | undefined> {
   const result = await db
     .select()
-    .from(montos)
-    .innerJoin(genders, eq(montos.genderId, genders.id))
-    .leftJoin(buddhistProfiles, eq(montos.id, buddhistProfiles.montoId))
-    .where(eq(montos.id, params.id))
+    .from(activeMontos)
+    .innerJoin(genders, eq(activeMontos.genderId, genders.id))
+    .leftJoin(buddhistProfiles, eq(activeMontos.id, buddhistProfiles.montoId))
+    .where(eq(activeMontos.id, params.id))
     .get();
 
   if (!result) {
@@ -106,19 +106,19 @@ export async function findOneMonto(
   }
 
   return {
-    id: result.montos.id,
+    id: result.active_montos.id,
     homyo: result.buddhist_profiles?.homyo ?? undefined,
-    firstName: result.montos.firstName,
-    lastName: result.montos.lastName,
+    firstName: result.active_montos.firstName,
+    lastName: result.active_montos.lastName,
     ingou: result.buddhist_profiles?.ingou ?? undefined,
-    dateOfDeath: result.montos.dateOfDeath
-      ? new Date(result.montos.dateOfDeath)
+    dateOfDeath: result.active_montos.dateOfDeath
+      ? new Date(result.active_montos.dateOfDeath)
       : undefined,
-    address: result.montos.address,
-    nextNenki: result.montos.dateOfDeath
-      ? nextNenki(new Date(result.montos.dateOfDeath))
+    address: result.active_montos.address,
+    nextNenki: result.active_montos.dateOfDeath
+      ? nextNenki(new Date(result.active_montos.dateOfDeath))
       : undefined,
-    phoneNumber: result.montos.phoneNumber,
+    phoneNumber: result.active_montos.phoneNumber,
     gender: result.genders.type,
   };
 }

--- a/application/packages/web/src/infrastructure/db/d1/schema.ts
+++ b/application/packages/web/src/infrastructure/db/d1/schema.ts
@@ -57,7 +57,6 @@ export const removeMontos = sqliteTable("remove_montos", {
   id: text().notNull().primaryKey(),
   montoId: text("monto_id")
     .notNull()
-    .unique()
     .references(() => montos.id),
   reason: text().notNull(), // temple_transfer | misregistration | others
   removedDate: text("removed_date").notNull(), // RFC3339 ex)2006-01-02T15:04:05Z07:00
@@ -67,7 +66,6 @@ export const restoreMontos = sqliteTable("restore_montos", {
   id: text().notNull().primaryKey(),
   montoId: text("monto_id")
     .notNull()
-    .unique()
     .references(() => montos.id),
   restoredDate: text("restored_date").notNull(), // RFC3339 ex)2006-01-02T15:04:05Z07:00
 });

--- a/application/packages/web/src/infrastructure/db/d1/schema.ts
+++ b/application/packages/web/src/infrastructure/db/d1/schema.ts
@@ -1,11 +1,22 @@
-import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { eq } from "drizzle-orm";
+import {
+  integer,
+  sqliteTable,
+  sqliteView,
+  text,
+} from "drizzle-orm/sqlite-core";
 
 export const genders = sqliteTable("genders", {
   id: integer({ mode: "number" }).primaryKey({ autoIncrement: true }),
-  type: text("type").notNull(),
+  type: text("type").notNull(), // MALE | FEMALE
   createdDate: text("created_date").notNull(), // RFC3339 ex)2006-01-02T15:04:05Z07:00
   updatedDate: text("updated_date").notNull(), // RFC3339 ex)2006-01-02T15:04:05Z07:00
 });
+
+const montoStatus = {
+  active: "ACTIVE",
+  inactive: "INACTIVE",
+};
 
 export const montos = sqliteTable("montos", {
   id: text().notNull().primaryKey(),
@@ -16,6 +27,7 @@ export const montos = sqliteTable("montos", {
   lastName: text("last_name").notNull(),
   phoneNumber: text("phone_number").notNull(),
   address: text("address").notNull(),
+  status: text("").notNull().default(montoStatus.active), // ACTIVE | INACTIVE
   dateOfDeath: text("date_of_death"), // RFC3339 ex)2006-01-02T15:04:05Z07:00
   createdDate: text("created_date").notNull(), // RFC3339 ex)2006-01-02T15:04:05Z07:00
   updatedDate: text("updated_date").notNull(), // RFC3339 ex)2006-01-02T15:04:05Z07:00
@@ -31,4 +43,33 @@ export const buddhistProfiles = sqliteTable("buddhist_profiles", {
   ingou: text(),
   createdDate: text("created_date").notNull(), // RFC3339 ex)2006-01-02T15:04:05Z07:00
   updatedDate: text("updated_date").notNull(), // RFC3339 ex)2006-01-02T15:04:05Z07:00
+});
+
+export const activeMontos = sqliteView("active_montos").as((db) =>
+  db.select().from(montos).where(eq(montos.status, montoStatus.active))
+);
+
+export const inactiveMontos = sqliteView("inactive_montos").as((db) =>
+  db.select().from(montos).where(eq(montos.status, montoStatus.inactive))
+);
+
+export const removeMontos = sqliteTable("remove_montos", {
+  id: text().notNull().primaryKey(),
+  montoId: text("monto_id")
+    .notNull()
+    .unique()
+    .references(() => montos.id),
+  reason: text().notNull(), // temple_transfer | misregistration | others
+  note: text(),
+  removedDate: text("removed_date").notNull(), // RFC3339 ex)2006-01-02T15:04:05Z07:00
+});
+
+export const restoreMontos = sqliteTable("restore_montos", {
+  id: text().notNull().primaryKey(),
+  montoId: text("monto_id")
+    .notNull()
+    .unique()
+    .references(() => montos.id),
+  note: text(),
+  restoredDate: text("restored_date").notNull(), // RFC3339 ex)2006-01-02T15:04:05Z07:00
 });

--- a/application/packages/web/src/infrastructure/db/d1/schema.ts
+++ b/application/packages/web/src/infrastructure/db/d1/schema.ts
@@ -27,7 +27,7 @@ export const montos = sqliteTable("montos", {
   lastName: text("last_name").notNull(),
   phoneNumber: text("phone_number").notNull(),
   address: text("address").notNull(),
-  status: text("").notNull().default(montoStatus.active), // ACTIVE | INACTIVE
+  status: text("status").notNull().default(montoStatus.active), // ACTIVE | INACTIVE
   dateOfDeath: text("date_of_death"), // RFC3339 ex)2006-01-02T15:04:05Z07:00
   createdDate: text("created_date").notNull(), // RFC3339 ex)2006-01-02T15:04:05Z07:00
   updatedDate: text("updated_date").notNull(), // RFC3339 ex)2006-01-02T15:04:05Z07:00
@@ -60,7 +60,6 @@ export const removeMontos = sqliteTable("remove_montos", {
     .unique()
     .references(() => montos.id),
   reason: text().notNull(), // temple_transfer | misregistration | others
-  note: text(),
   removedDate: text("removed_date").notNull(), // RFC3339 ex)2006-01-02T15:04:05Z07:00
 });
 
@@ -70,6 +69,5 @@ export const restoreMontos = sqliteTable("restore_montos", {
     .notNull()
     .unique()
     .references(() => montos.id),
-  note: text(),
   restoredDate: text("restored_date").notNull(), // RFC3339 ex)2006-01-02T15:04:05Z07:00
 });

--- a/application/packages/web/src/infrastructure/db/d1/schema.ts
+++ b/application/packages/web/src/infrastructure/db/d1/schema.ts
@@ -6,9 +6,18 @@ import {
   text,
 } from "drizzle-orm/sqlite-core";
 
+// Cloudflare D1 transaction not supported.
+// https://github.com/drizzle-team/drizzle-orm/issues/2463
+// Locking using INSERT to unique key.
+// key example: `${montoId}:update`
+export const locks = sqliteTable("locks", {
+  key: text().notNull().primaryKey(),
+  lockedDate: text("locked_date").notNull(), // RFC3339 ex)2006-01-02T15:04:05Z07:00
+});
+
 export const genders = sqliteTable("genders", {
   id: integer({ mode: "number" }).primaryKey({ autoIncrement: true }),
-  type: text("type").notNull(), // MALE | FEMALE
+  type: text().notNull(), // MALE | FEMALE
   createdDate: text("created_date").notNull(), // RFC3339 ex)2006-01-02T15:04:05Z07:00
   updatedDate: text("updated_date").notNull(), // RFC3339 ex)2006-01-02T15:04:05Z07:00
 });

--- a/application/packages/web/src/infrastructure/db/d1/schema.ts
+++ b/application/packages/web/src/infrastructure/db/d1/schema.ts
@@ -8,8 +8,8 @@ import {
 
 // Cloudflare D1 transaction not supported.
 // https://github.com/drizzle-team/drizzle-orm/issues/2463
-// Locking using INSERT to unique key.
-// key example: `${montoId}:update`
+// Locking using INSERT to unique key. key example: `${montoId}:update`
+// Locks that have not been released for a certain period of time are deleted in a batch process.
 export const locks = sqliteTable("locks", {
   key: text().notNull().primaryKey(),
   lockedDate: text("locked_date").notNull(), // RFC3339 ex)2006-01-02T15:04:05Z07:00

--- a/application/packages/web/src/infrastructure/db/d1/schema.ts
+++ b/application/packages/web/src/infrastructure/db/d1/schema.ts
@@ -58,7 +58,7 @@ export const removeMontos = sqliteTable("remove_montos", {
   montoId: text("monto_id")
     .notNull()
     .references(() => montos.id),
-  reason: text().notNull(), // temple_transfer | misregistration | others
+  reason: text().notNull(), // TEMPLE_TRANSFER | MISREGISTRATION | OTHERS
   removedDate: text("removed_date").notNull(), // RFC3339 ex)2006-01-02T15:04:05Z07:00
 });
 

--- a/application/packages/web/src/pages/409.tsx
+++ b/application/packages/web/src/pages/409.tsx
@@ -1,0 +1,15 @@
+const Error409 = () => (
+  <div className="min-h-screen flex items-center justify-center">
+    <div className="text-center">
+      <h1 className="text-3xl font-bold mb-4">409エラー</h1>
+      <h2 className="mb-2">
+        処理の競合が発生しました。時間を置いて再度お試しください。
+      </h2>
+      <a href="/" className="text-blue-600 hover:underline">
+        ←お品書きに戻る
+      </a>
+    </div>
+  </div>
+);
+
+export default Error409;

--- a/application/packages/web/src/usecase/error/conflict.ts
+++ b/application/packages/web/src/usecase/error/conflict.ts
@@ -1,0 +1,9 @@
+export class ConflictError extends Error {
+  type = "Conflict";
+  readonly details?: string;
+
+  constructor(msg: string, details?: string) {
+    super(msg);
+    this.details = details;
+  }
+}

--- a/application/packages/web/src/usecase/lockKey.ts
+++ b/application/packages/web/src/usecase/lockKey.ts
@@ -1,0 +1,3 @@
+export function lockKeyForUpdateMonto(id: string): `updateMonto:${string}` {
+  return `updateMonto:${id}`;
+}

--- a/application/packages/web/src/usecase/removeMonto.ts
+++ b/application/packages/web/src/usecase/removeMonto.ts
@@ -3,8 +3,10 @@ import {
   inactiveSavedMonto,
   SavedMonto,
 } from "../domain/model/monto";
+import { ConflictError } from "./error/conflict";
 import { InvalidParameterError } from "./error/invalidPrameter";
 import { NotFoundError } from "./error/notFound";
+import { lockKeyForUpdateMonto } from "./lockKey";
 
 export type Input = {
   id: string;
@@ -14,12 +16,30 @@ export type Input = {
 export type Dependency = {
   findMonto: (id: string) => Promise<SavedMonto | undefined>;
   updateMonto: (savedMonto: SavedMonto) => Promise<void>;
+  lock: (key: string) => Promise<boolean>;
+  unlock: (key: string) => Promise<void>;
 };
 
 export async function removeMonto(
   input: Input,
   dep: Dependency
 ): Promise<void> {
+  const lockKey = lockKeyForUpdateMonto(input.id);
+  if (!(await dep.lock(lockKey))) {
+    throw new ConflictError("Monto update alreacy locked.");
+  }
+  try {
+    await _removeMonto(input, dep);
+  } finally {
+    try {
+      await dep.unlock(lockKey);
+    } catch (e) {
+      console.log(e);
+    }
+  }
+}
+
+async function _removeMonto(input: Input, dep: Dependency): Promise<void> {
   const monto = await dep.findMonto(input.id);
   if (!monto) {
     throw new NotFoundError("monto not found");

--- a/application/packages/web/src/usecase/removeMonto.ts
+++ b/application/packages/web/src/usecase/removeMonto.ts
@@ -34,7 +34,11 @@ export async function removeMonto(
     try {
       await dep.unlock(lockKey);
     } catch (e) {
-      console.log(e);
+      console.log(
+        `Failed to unlock monto update, ${
+          e instanceof Error ? e.message : JSON.stringify(e)
+        }`
+      );
     }
   }
 }

--- a/application/packages/web/src/usecase/removeMonto.ts
+++ b/application/packages/web/src/usecase/removeMonto.ts
@@ -1,10 +1,14 @@
-import { inactiveSavedMonto, SavedMonto } from "../domain/model/monto";
+import {
+  InactiveMontoReason,
+  inactiveSavedMonto,
+  SavedMonto,
+} from "../domain/model/monto";
 import { InvalidParameterError } from "./error/invalidPrameter";
 import { NotFoundError } from "./error/notFound";
 
 export type Input = {
   id: string;
-  reason: string;
+  reason: InactiveMontoReason;
 };
 
 export type Dependency = {

--- a/application/packages/web/src/usecase/removeMonto.ts
+++ b/application/packages/web/src/usecase/removeMonto.ts
@@ -1,9 +1,10 @@
-import { SavedMonto, activeSavedMonto } from "../domain/model/monto";
+import { inactiveSavedMonto, SavedMonto } from "../domain/model/monto";
 import { InvalidParameterError } from "./error/invalidPrameter";
 import { NotFoundError } from "./error/notFound";
 
 export type Input = {
   id: string;
+  reason: string;
 };
 
 export type Dependency = {
@@ -11,7 +12,7 @@ export type Dependency = {
   updateMonto: (savedMonto: SavedMonto) => Promise<void>;
 };
 
-export async function restoreMonto(
+export async function removeMonto(
   input: Input,
   dep: Dependency
 ): Promise<void> {
@@ -20,17 +21,17 @@ export async function restoreMonto(
     throw new NotFoundError("monto not found");
   }
 
-  if (monto.status === "ACTIVE") {
+  if (monto.status === "INACTIVE") {
     return;
   }
 
-  const activeMontoOrError = activeSavedMonto(monto);
-  if (activeMontoOrError instanceof Error) {
+  const inactiveMontoOrError = inactiveSavedMonto(monto, input.reason);
+  if (inactiveMontoOrError instanceof Error) {
     throw new InvalidParameterError(
       "Invalid remove monto parameter",
-      activeMontoOrError.message
+      inactiveMontoOrError.message
     );
   }
 
-  await dep.updateMonto(activeMontoOrError);
+  await dep.updateMonto(inactiveMontoOrError);
 }

--- a/application/packages/web/src/usecase/restoreMonto.ts
+++ b/application/packages/web/src/usecase/restoreMonto.ts
@@ -1,0 +1,33 @@
+import { SavedMonto, activeSavedMonto } from "../domain/model/monto";
+import { NotFoundError } from "./error/notFound";
+
+export type Input = {
+  id: string;
+};
+
+export type Dependency = {
+  findMonto: (id: string) => Promise<SavedMonto | undefined>;
+  updateMonto: (savedMonto: SavedMonto) => Promise<void>;
+};
+
+export async function restoreMonto(
+  input: Input,
+  dep: Dependency
+): Promise<void> {
+  const monto = await dep.findMonto(input.id);
+  if (!monto) {
+    throw new NotFoundError("monto not found");
+  }
+
+  if (monto.status === "ACTIVE") {
+    return;
+  }
+
+  const activeMontoOrError = activeSavedMonto(monto);
+  if (activeMontoOrError instanceof Error) {
+    // Should not throw InvalidParameterError because input has only id.
+    throw activeMontoOrError;
+  }
+
+  await dep.updateMonto(activeMontoOrError);
+}

--- a/application/packages/web/src/usecase/restoreMonto.ts
+++ b/application/packages/web/src/usecase/restoreMonto.ts
@@ -29,7 +29,11 @@ export async function restoreMonto(
     try {
       await dep.unlock(lockKey);
     } catch (e) {
-      console.log(e);
+      console.log(
+        `Failed to unlock monto update, ${
+          e instanceof Error ? e.message : JSON.stringify(e)
+        }`
+      );
     }
   }
 }

--- a/application/packages/web/src/usecase/restoreMonto.ts
+++ b/application/packages/web/src/usecase/restoreMonto.ts
@@ -1,6 +1,8 @@
 import { SavedMonto, activeSavedMonto } from "../domain/model/monto";
+import { ConflictError } from "./error/conflict";
 import { InvalidParameterError } from "./error/invalidPrameter";
 import { NotFoundError } from "./error/notFound";
+import { lockKeyForUpdateMonto } from "./lockKey";
 
 export type Input = {
   id: string;
@@ -9,12 +11,30 @@ export type Input = {
 export type Dependency = {
   findMonto: (id: string) => Promise<SavedMonto | undefined>;
   updateMonto: (savedMonto: SavedMonto) => Promise<void>;
+  lock: (key: string) => Promise<boolean>;
+  unlock: (key: string) => Promise<void>;
 };
 
 export async function restoreMonto(
   input: Input,
   dep: Dependency
 ): Promise<void> {
+  const lockKey = lockKeyForUpdateMonto(input.id);
+  if (!(await dep.lock(lockKey))) {
+    throw new ConflictError("Monto update alreacy locked.");
+  }
+  try {
+    await _restoreMonto(input, dep);
+  } finally {
+    try {
+      await dep.unlock(lockKey);
+    } catch (e) {
+      console.log(e);
+    }
+  }
+}
+
+async function _restoreMonto(input: Input, dep: Dependency): Promise<void> {
   const monto = await dep.findMonto(input.id);
   if (!monto) {
     throw new NotFoundError("monto not found");

--- a/application/packages/web/src/usecase/updateMonto.ts
+++ b/application/packages/web/src/usecase/updateMonto.ts
@@ -17,7 +17,7 @@ export type Dependency = {
   findMonto: (id: string) => Promise<SavedMonto | undefined>;
   updateMonto: (savedMonto: SavedMonto) => Promise<void>;
   lock: (key: string) => Promise<boolean>;
-  unock: (key: string) => Promise<void>;
+  unlock: (key: string) => Promise<void>;
 };
 
 export async function updateMonto(
@@ -32,7 +32,7 @@ export async function updateMonto(
     await _updateMonto(input, dep);
   } finally {
     try {
-      await dep.unock(lockKey);
+      await dep.unlock(lockKey);
     } catch (e) {
       console.log(e);
     }

--- a/application/packages/web/src/usecase/updateMonto.ts
+++ b/application/packages/web/src/usecase/updateMonto.ts
@@ -1,6 +1,8 @@
 import { SavedMonto, modifiedSavedMonto } from "../domain/model/monto";
+import { ConflictError } from "./error/conflict";
 import { InvalidParameterError } from "./error/invalidPrameter";
 import { NotFoundError } from "./error/notFound";
+import { lockKeyForUpdateMonto } from "./lockKey";
 
 export type Input = {
   id: string;
@@ -14,12 +16,30 @@ export type Input = {
 export type Dependency = {
   findMonto: (id: string) => Promise<SavedMonto | undefined>;
   updateMonto: (savedMonto: SavedMonto) => Promise<void>;
+  lock: (key: string) => Promise<boolean>;
+  unock: (key: string) => Promise<void>;
 };
 
 export async function updateMonto(
   input: Input,
   dep: Dependency
 ): Promise<void> {
+  const lockKey = lockKeyForUpdateMonto(input.id);
+  if (!(await dep.lock(lockKey))) {
+    throw new ConflictError("Monto update alreacy locked.");
+  }
+  try {
+    await _updateMonto(input, dep);
+  } finally {
+    try {
+      await dep.unock(lockKey);
+    } catch (e) {
+      console.log(e);
+    }
+  }
+}
+
+async function _updateMonto(input: Input, dep: Dependency): Promise<void> {
   const monto = await dep.findMonto(input.id);
   if (!monto) {
     throw new NotFoundError("monto not found");

--- a/application/packages/web/src/usecase/updateMonto.ts
+++ b/application/packages/web/src/usecase/updateMonto.ts
@@ -34,7 +34,11 @@ export async function updateMonto(
     try {
       await dep.unlock(lockKey);
     } catch (e) {
-      console.log(e);
+      console.log(
+        `Failed to unlock monto update, ${
+          e instanceof Error ? e.message : JSON.stringify(e)
+        }`
+      );
     }
   }
 }

--- a/application/packages/web/wrangler.e2e.json
+++ b/application/packages/web/wrangler.e2e.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "kimyou",
   "main": "src/index.tsx",
-  "compatibility_date": "2025-02-06",
+  "compatibility_date": "2025-02-04",
   "compatibility_flags": ["nodejs_compat"],
   "vars": {
     "ENV": "local"

--- a/application/packages/web/wrangler.local.json
+++ b/application/packages/web/wrangler.local.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "kimyou",
   "main": "src/index.tsx",
-  "compatibility_date": "2025-02-06",
+  "compatibility_date": "2025-02-04",
   "compatibility_flags": ["nodejs_compat"],
   "vars": {
     "ENV": "local"


### PR DESCRIPTION
- Add migration for remove and restore montos tables, update montos schema with status field, and create active/inactive montos views
- feat: Use activeMontos instead of montos
- feat: Add Monto status handling and schemas for active/inactive montos
- refactor: Define SavedMonto type for improved type inference in monto model
- feat: Add inactiveMonto handling with reason validation and parsing function
- feat: Add activeSavedMonto function for parsing active montos from inactive schema
- feat: Remove unnecessary comment regarding unexpected HTML input validation errors
- feat: Implement restoreMonto function to handle restoring inactive montos
- feat: Implement removeMonto function for handling monto removal with validation
- feat: Introduce custom error classes for invalid monto handling and update parsing functions
- feat: Remove 'note' column from remove_montos and restore_montos tables
- feat: Remove unused createdDate variable and related console log from updateMonto function
- feat: Enhance updateMonto function to handle status changes with event logging for restoration and removal
- fix: Use a single timestamp variable for createdDate and updatedDate
- feat: Add removeMonto and restoreMonto handlers with validation and database integration
- feat: Add ID parameter validation to removeMonto and restoreMonto handlers
- fix: Remove unique constraint from montoId in removeMontos and restoreMontos tables
- feat: Add migration to drop unique indexes on montoId in removeMontos and restoreMontos tables
- fix: Simplify status check logic in updateMonto function
- feat: Add status property to inactiveSavedMonto and activeSavedMonto functions
- feat: Introduce inactiveMontoReason type and validation for removeMonto handler
- feat: Add locks table for managing concurrent operations
- feat: Implement locking mechanism with getLock and releaseLock functions
- feat: Add Error 409 page for handling conflict errors
- feat: Rename getLock to lock and update to return boolean for lock status
- feat: Add lockKeyForUpdateMonto function for generating updateMonto keys
- feat: Implement locking in updateMonto to prevent concurrent updates
- feat: Enhance editMontoAction with locking mechanism and conflict handling
- fix: Correct typo in unlock function name in editMontoAction and updateMonto
- feat: Implement locking mechanism in removeMonto and restoreMonto to prevent concurrent updates
- feat: Integrate locking mechanism in removeMonto and restoreMonto for concurrent update prevention
- fix: Improve error logging in unlock function for removeMonto, restoreMonto, and updateMonto
- fix: Update compatibility date in wrangler configuration files
